### PR TITLE
Add daemons.conf to playbook

### DIFF
--- a/config/daemons.conf
+++ b/config/daemons.conf
@@ -1,0 +1,21 @@
+##################
+# TEMPORARY WORKAROUND
+# we are taking advantage of qlyoung's good will to make this file backwards compatibile
+#
+vtysh_enable=yes
+zebra_options="  -M snmp -A 127.0.0.1 -s 90000000"
+bgpd_options="   -M snmp -A 127.0.0.1"
+ospfd_options="  -M snmp -A 127.0.0.1"
+ospf6d_options=" -M snmp -A ::1"
+ripd_options="   -A 127.0.0.1"
+ripngd_options=" -A ::1"
+isisd_options="  -A 127.0.0.1"
+pimd_options="   -A 127.0.0.1"
+ldpd_options="   -A 127.0.0.1"
+nhrpd_options="  -A 127.0.0.1"
+eigrpd_options=" -A 127.0.0.1"
+babeld_options=" -A 127.0.0.1"
+sharpd_options=" -A 127.0.0.1"
+pbrd_options="   -A 127.0.0.1"
+staticd_options="-A 127.0.0.1"
+vrrpd_options="  -A 127.0.0.1"

--- a/roles/routing_configuration/tasks/main.yml
+++ b/roles/routing_configuration/tasks/main.yml
@@ -2,6 +2,9 @@
   - name: copy FRR daemons
     copy: src=config/daemons dest=/etc/frr/
 
+  - name: copy FRR daemons.conf
+    copy: src=config/daemons.conf dest=/etc/frr/
+
   - name: copy FRR conf
     copy: src=config/{{ansible_hostname}}/frr.conf dest=/etc/frr/
 


### PR DESCRIPTION
This commit adds daemons.conf so we don't cause buffer overflows
in the lab for switches running CL 4.x.

THIS IS A TEMPORARY WORKAROUND UNTIL PROPER LOGIC IS ADDED TO PLAYBOOK

Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>