### PR TITLE
Avoid ssh key/host checking

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,8 @@ inventory = ./hosts
 # hostfile=./hosts
 # only use in lab settings. Reference:
 # http://docs.ansible.com/intro_getting_started.html#host-key-checking
-host_key_checking=False
+host_key_checking = False
+
+[ssh_connection]
+# use with 'host_key_checking = False' to avoid ssh key checks
+ssh_args = -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
Add ssh_args to ansible.cfg to disable host checking, i.e.
no more 'WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!' errors

Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>