### PR TITLE
Stop overwriting daemons.conf for CL 3.x

### DIFF
--- a/roles/routing_configuration/tasks/main.yml
+++ b/roles/routing_configuration/tasks/main.yml
@@ -4,10 +4,10 @@
 
   - name: copy FRR daemons.conf
     copy: src=config/daemons.conf dest=/etc/frr/
+    when: "{{ansible_lsb.release is version_compare('4.0', '>=') }}"
 
   - name: copy FRR conf
     copy: src=config/{{ansible_hostname}}/frr.conf dest=/etc/frr/
 
   - name: Restart FRR
     service: name=frr state=restarted
-


### PR DESCRIPTION
Overwriting daemons.conf on 3.x was causing FRR to stall out
during service start.  Let's add in some logic to stop doing this.

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>